### PR TITLE
Fix macos compilation error

### DIFF
--- a/cli/src/util/clipboard.rs
+++ b/cli/src/util/clipboard.rs
@@ -662,7 +662,7 @@ pub(crate) struct NotifyHandle(
 impl NotifyHandle {
     /// Explicitly close the notification
     fn close(self) {
-        #[cfg(all(feature = "notify", not(target_env = "musl")))]
+        #[cfg(all(feature = "notify", not(target_env = "musl"), not(target_os = "macos")))]
         self.0.close();
     }
 }


### PR DESCRIPTION
On macOS, 

```
  error[E0599]: no method named `close` found for struct `NotificationHandle` in the current scope
     --> cli/src/util/clipboard.rs:666:16
      |
  666 |         self.0.close();
      |                ^^^^^
```

error happen and so exclude `macos`.