### PR TITLE
docs: Add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,15 @@ You can use `prs` from the command line in the same directory:
 To make it globally invocable as `prs`, you must make the binary available in
 your systems `PATH`.
 
+#### X-CMD
+
+Maybe using [x-cmd](https://www.x-cmd.com/mod/eget):
+
+```bash
+x eget use timvisee/prs
+prs --help
+```
+
 #### Other
 
 Find the latest binaries on the latest release page:


### PR DESCRIPTION
Add `x eget` as an installation method for prs.

`x eget` allows users to install prs directly from its GitHub release:

```sh
x eget use timvisee/prs
```